### PR TITLE
Make Database singleton

### DIFF
--- a/app/src/main/java/com/T05/krowdtrialz/MainActivity.java
+++ b/app/src/main/java/com/T05/krowdtrialz/MainActivity.java
@@ -1,23 +1,7 @@
 package com.T05.krowdtrialz;
 
 import android.content.SharedPreferences;
-import android.location.Location;
-import android.location.LocationManager;
 import android.os.Bundle;
-import android.util.Log;
-
-import com.T05.krowdtrialz.model.experiment.BinomialExperiment;
-import com.T05.krowdtrialz.model.experiment.CountExperiment;
-import com.T05.krowdtrialz.model.experiment.Experiment;
-import com.T05.krowdtrialz.model.experiment.IntegerExperiment;
-import com.T05.krowdtrialz.model.experiment.MeasurementExperiment;
-import com.T05.krowdtrialz.model.trial.BinomialTrial;
-import com.T05.krowdtrialz.model.trial.Trial;
-import com.T05.krowdtrialz.model.user.User;
-import com.T05.krowdtrialz.util.Database;
-import com.google.android.material.bottomnavigation.BottomNavigationView;
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.navigation.NavController;
@@ -25,15 +9,12 @@ import androidx.navigation.Navigation;
 import androidx.navigation.ui.AppBarConfiguration;
 import androidx.navigation.ui.NavigationUI;
 
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Random;
-import java.util.UUID;
+import com.T05.krowdtrialz.util.Database;
+import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private Database db = new Database();
-    private String localID;
+    private Database db;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -49,56 +30,12 @@ public class MainActivity extends AppCompatActivity {
         NavigationUI.setupActionBarWithNavController(this, navController, appBarConfiguration);
         NavigationUI.setupWithNavController(navView, navController);
 
+        // Initialize the Database instance.
+        SharedPreferences sharedPreferences = getSharedPreferences("shared_P", MODE_PRIVATE);
+        Database.initializeInstance(sharedPreferences);
+        db = Database.getInstance();
+        // Generate a unique ID if one has not already been generated.
+        db.loadID();
     }
-
-    /**
-     * This saves unique id after loadID generates a unique id
-     * @author
-     *  Furmaan Sekhon and Jacques Leong-Sit
-     */
-    public void saveID() {
-
-        // allows variable to be saved
-        SharedPreferences sharedP = getSharedPreferences("shared_P", MODE_PRIVATE);
-        SharedPreferences.Editor editor = sharedP.edit();
-        Gson gson = new Gson();
-        String convertedID = gson.toJson(localID); // converts arrayList to json
-        editor.putString("ID",convertedID); // saves converted arrayList
-        editor.apply();
-        Log.d("saveID","Saved"+localID);
-
-    }// end saveID
-
-    /**
-     * This checks if the device already has an id saved if not it generates unique id and saves it to device
-     * @author
-     *  Furmaan Sekhon and Jacques Leong-Sit
-     */
-    public void loadID() {
-
-        SharedPreferences sharedP = getSharedPreferences("shared_P", MODE_PRIVATE);
-        Gson gson = new Gson();
-        String convertedID = sharedP.getString("ID", null);// gets saved arrayList (in json form) null if there is none saved
-        Type type = new TypeToken<String>() {}.getType();
-        localID = gson.fromJson(convertedID, type);
-
-
-        if (localID == null) {
-            UUID uuid = UUID.randomUUID();
-            localID = uuid.toString();
-            db.verifyID(localID.toString(),new Database.GenerateIDCallback() {
-                @Override
-                public void onSuccess(String id) {
-                    saveID();
-                }
-
-                @Override
-                public void onFailure() {
-                    loadID();
-                }
-            });
-        }
-
-    }// end loadID
 
 }// end MainActivity

--- a/app/src/main/java/com/T05/krowdtrialz/MainActivity.java
+++ b/app/src/main/java/com/T05/krowdtrialz/MainActivity.java
@@ -34,8 +34,8 @@ public class MainActivity extends AppCompatActivity {
         SharedPreferences sharedPreferences = getSharedPreferences("shared_P", MODE_PRIVATE);
         Database.initializeInstance(sharedPreferences);
         db = Database.getInstance();
-        // Generate a unique ID if one has not already been generated.
-        db.loadID();
+        // Generate a new user with unique ID or fetch information for an existing user.
+        db.initializeDeviceUser();
     }
 
 }// end MainActivity

--- a/app/src/main/java/com/T05/krowdtrialz/model/user/User.java
+++ b/app/src/main/java/com/T05/krowdtrialz/model/user/User.java
@@ -9,6 +9,10 @@ public class User {
     public User() {
     }
 
+    public User(String id) {
+        this(null, null, null, id);
+    }
+
     public User(String name, String userName, String email, String id) {
         this.name = name;
         this.userName = userName;

--- a/app/src/main/java/com/T05/krowdtrialz/util/Database.java
+++ b/app/src/main/java/com/T05/krowdtrialz/util/Database.java
@@ -103,7 +103,7 @@ public class Database {
         String convertedID = gson.toJson(localID); // converts arrayList to json
         editor.putString("ID",convertedID); // saves converted arrayList
         editor.apply();
-        Log.d("saveID","Saved"+localID);
+        Log.d("saveID","Saved ID: "+localID);
 
     }// end saveID
 
@@ -133,7 +133,7 @@ public class Database {
 
             verifyUserID(deviceUser, new Database.GenerateIDCallback() {
                 @Override
-                public void onSuccess(String id) {
+                public void onSuccess(User user) {
                     saveID();
                 }
 
@@ -149,6 +149,8 @@ public class Database {
                 @Override
                 public void onSuccess(User user) {
                     deviceUser = user;
+                    Log.d(TAG, "Successfully retrieved existing user information from database."
+                            + " ID: " + deviceUser.getId());
                 }
 
                 @Override
@@ -202,7 +204,7 @@ public class Database {
         db = FirebaseFirestore.getInstance();
         CollectionReference userCollectionReference = db.collection("Users");
 
-        Query query = userCollectionReference.whereEqualTo("User.id", id); // Create a query to check if ID exists in the database already
+        Query query = userCollectionReference.whereEqualTo("id", id); // Create a query to check if ID exists in the database already
         query.get().addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
             @Override
             public void onComplete(@NonNull Task<QuerySnapshot> task) {
@@ -232,7 +234,7 @@ public class Database {
         db = FirebaseFirestore.getInstance();
         CollectionReference userCollectionReference = db.collection("Users");
 
-        Query query = userCollectionReference.whereEqualTo("User.id", user.getId()); // Create a query to check if ID exists in the database already
+        Query query = userCollectionReference.whereEqualTo("id", user.getId()); // Create a query to check if ID exists in the database already
 
         query.get().addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
             @Override
@@ -240,16 +242,14 @@ public class Database {
                 if(task.getResult().isEmpty()) {
                     // create new user in the database
                     // This means the id generated is unique
-                    HashMap<String, Object> newUser = new HashMap<>();
-                    newUser.put("User", user);
                     userCollectionReference
                             .document(user.getId())
-                            .set(newUser)
+                            .set(user)
                             .addOnSuccessListener(new OnSuccessListener<Void>() {
                                 @Override
                                 public void onSuccess(Void aVoid) {
                                     Log.d(TAG, "Data has been added");
-                                    callback.onSuccess(user.getId());
+                                    callback.onSuccess(user);
                                 }
                             })
                             .addOnFailureListener(new OnFailureListener() {
@@ -547,7 +547,7 @@ public class Database {
      *  Furmaan Sekhon and Jacques Leong-Sit and Ryan Shukla
      */
     public interface GenerateIDCallback  {
-        public void onSuccess(String id);
+        public void onSuccess(User user);
         public void onFailure();
 
     }// end GenerateIDCallback


### PR DESCRIPTION
This allows any activity or fragment to access the same Database instance.
This makes it easy to get information such as the device's ID.

- Create initializeInstance method to pass SharedPreferences to Database instance
- Call initializeInstance in MainActivity
- Move loadID and saveID methods from MainActivity to Database
  - rename loadID to initializeDeviceUser()
- Add Database method getDeviceUser() that gets the User instance associated with the device (i.e. has the correct id)