### PR TITLE
Initialize Database in splash screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,22 +9,24 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.KrowdTrialz">
-        <activity android:name=".ui.search.SearchActivity"
-            android:windowSoftInputMode="adjustNothing">
-        </activity>
-        <activity android:name=".ui.owner.ContributorsActivity"
-            android:parentActivityName=".ui.ExperimentDetailsOwnerActivity">
-        </activity>
-        <activity android:name=".ui.ExperimentDetailsNonOwnerActivity" />
-        <activity android:name=".ui.ExperimentDetailsOwnerActivity" />
-        <activity
-            android:name=".MainActivity"
-            android:label="@string/app_name">
+        <activity android:name=".ui.SplashActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".ui.search.SearchActivity"
+            android:windowSoftInputMode="adjustNothing" />
+        <activity
+            android:name=".ui.owner.ContributorsActivity"
+            android:parentActivityName=".ui.ExperimentDetailsOwnerActivity" />
+        <activity android:name=".ui.ExperimentDetailsNonOwnerActivity" />
+        <activity android:name=".ui.ExperimentDetailsOwnerActivity" />
+        <activity
+            android:name=".MainActivity"
+            android:label="@string/app_name">
         </activity>
     </application>
 

--- a/app/src/main/java/com/T05/krowdtrialz/MainActivity.java
+++ b/app/src/main/java/com/T05/krowdtrialz/MainActivity.java
@@ -60,14 +60,6 @@ public class MainActivity extends AppCompatActivity {
                 startActivity(intent);
             }
         });
-
-        // Initialize the Database instance.
-        SharedPreferences sharedPreferences = getSharedPreferences("shared_P", MODE_PRIVATE);
-        Database.initializeInstance(sharedPreferences);
-        db = Database.getInstance();
-        // Generate a new user with unique ID or fetch information for an existing user.
-        db.initializeDeviceUser();
-
     }
 
 }// end MainActivity

--- a/app/src/main/java/com/T05/krowdtrialz/ui/SplashActivity.java
+++ b/app/src/main/java/com/T05/krowdtrialz/ui/SplashActivity.java
@@ -1,0 +1,51 @@
+package com.T05.krowdtrialz.ui;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.util.Log;
+
+import com.T05.krowdtrialz.MainActivity;
+import com.T05.krowdtrialz.R;
+import com.T05.krowdtrialz.ui.search.SearchActivity;
+import com.T05.krowdtrialz.util.Database;
+
+/**
+ * This is the splash screen for the app.
+ * This activity initializes the Database instance and will not start MainActivity until that
+ * initialization has finished.
+ *
+ * @author Ryan Shukla
+ */
+public class SplashActivity extends AppCompatActivity {
+    private final String TAG = "SPLASH ACTIVITY";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_splash);
+
+        // Initialize the Database instance.
+        SharedPreferences sharedPreferences = getSharedPreferences("shared_P", MODE_PRIVATE);
+        Database.initializeInstance(sharedPreferences,
+                new Database.InitializeDatabaseCallback() {
+                    @Override
+                    public void onSuccess() {
+                        startMainActivity();
+                    }
+
+                    @Override
+                    public void onFailure() {
+                        Log.e(TAG, "Failed to initialize Database instance");
+                    }
+                });
+    }
+
+    private void startMainActivity() {
+        Log.d(TAG, "Starting MainActivity");
+        Intent intent = new Intent(this, MainActivity.class);
+        startActivity(intent);
+    }
+}

--- a/app/src/main/java/com/T05/krowdtrialz/util/Database.java
+++ b/app/src/main/java/com/T05/krowdtrialz/util/Database.java
@@ -64,10 +64,14 @@ public class Database {
      * This should be called from MainActivity when the app starts.
      * @author Ryan Shukla
      * @param sharedPreferences The app's instance of SharedPreferences.
+     * @param callback Callback to be called when all initialization is finished.
      */
-    public static void initializeInstance(SharedPreferences sharedPreferences) {
+    public static void initializeInstance(
+            SharedPreferences sharedPreferences,
+            InitializeDatabaseCallback callback) {
         if (instance == null) {
             instance = new Database(sharedPreferences);
+            instance.initializeDeviceUser(callback);
         }
     }
 
@@ -96,7 +100,7 @@ public class Database {
      * @author
      *  Furmaan Sekhon and Jacques Leong-Sit
      */
-    private void saveID() {
+    private void saveID(InitializeDatabaseCallback callback) {
 
         // allows variable to be saved
         SharedPreferences.Editor editor = sharedPreferences.edit();
@@ -107,6 +111,8 @@ public class Database {
         editor.apply();
         Log.d("saveID","Saved ID: "+localID);
 
+        callback.onSuccess();
+
     }// end saveID
 
     /**
@@ -116,7 +122,8 @@ public class Database {
      * @author
      *  Furmaan Sekhon and Jacques Leong-Sit
      */
-    public void initializeDeviceUser() {
+    public void initializeDeviceUser(InitializeDatabaseCallback callback) {
+        Log.d(TAG, "initializeDeviceUser");
 
         Gson gson = new Gson();
         String convertedID = sharedPreferences.getString("ID", null);// gets saved arrayList (in json form) null if there is none saved
@@ -131,18 +138,19 @@ public class Database {
             localID = uuid.toString();
 
             // Create new User with default contact information
+            Log.d(TAG, "construct deviceUser");
             deviceUser = new User(localID.toString());
 
             verifyUserID(deviceUser, new Database.GenerateIDCallback() {
                 @Override
                 public void onSuccess(User user) {
-                    saveID();
+                    saveID(callback);
                 }
 
                 @Override
                 public void onFailure() {
                     // ID was not unique, try again
-                    initializeDeviceUser();
+                    initializeDeviceUser(callback);
                 }
             });
         } else {
@@ -153,11 +161,13 @@ public class Database {
                     deviceUser = user;
                     Log.d(TAG, "Successfully retrieved existing user information from database."
                             + " ID: " + deviceUser.getId());
+                    callback.onSuccess();
                 }
 
                 @Override
                 public void onFailure() {
                     Log.e(TAG, "Failed to find user in database with ID from SharedPreferences.");
+                    callback.onFailure();
                 }
             });
         }
@@ -636,6 +646,15 @@ public class Database {
      */
     public interface GetUserCallback {
         public void onSuccess(User user);
+        public void onFailure();
+    }
+
+    /**
+     * Callback for when initializeInstance is finished.
+     * @author Ryan Shukla
+     */
+    public interface InitializeDatabaseCallback {
+        public void onSuccess();
         public void onFailure();
     }
 }// end Database

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.SplashActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This creates a new activity called SplashActivity.
SplashActivity waits until all the initialization for the Database is done
before starting MainActivity.
This is done to fix issues where fragments where calling getDeviceUser() before
the user was initialized properly.

This also adds a parameter to Database.initializeInstance() which is a callback
that is called when all the initialization is finished.