### PR TITLE
Fix error where experimentsList contained a null ArrayList

### DIFF
--- a/app/src/main/java/com/T05/krowdtrialz/ui/subscribed/SubscribedViewModel.java
+++ b/app/src/main/java/com/T05/krowdtrialz/ui/subscribed/SubscribedViewModel.java
@@ -27,8 +27,9 @@ public class SubscribedViewModel extends ViewModel {
         db.getExperimentsBySubscriber(db.getDeviceUser(), new Database.QueryExperimentsCallback() {
             @Override
             public void onSuccess(ArrayList<Experiment> experiments) {
-                experimentsList.getValue().clear();
-                experimentsList.getValue().addAll(experiments);
+                ArrayList<Experiment> newList = new ArrayList<>();
+                newList.addAll(experiments);
+                experimentsList.setValue(newList);
                 Log.d(TAG, "Got query results: " + experiments.toString());
             }
 


### PR DESCRIPTION
This fixes the following fatal error. This error was crashing the app for me immediately when it was launched. I was getting this error on my physical device but not in the emulator. I'm not sure why it doesn't always happen.

![backtrace](https://user-images.githubusercontent.com/4721319/111357096-9b89c300-864e-11eb-82ca-49909c0770c4.png)

The fix is to call `setValue` on the `MutableLiveData` because `LiveData` instances initially have no value set. See: https://developer.android.com/topic/libraries/architecture/livedata

I think calling `setValue` instead of mutating the `ArrayList` itself is the correct way to do this since `setValue` will notify observers.