### PR TITLE
Modify more Database methods to support live updating

### DIFF
--- a/app/src/main/java/com/T05/krowdtrialz/ui/contributors/ContributorsActivity.java
+++ b/app/src/main/java/com/T05/krowdtrialz/ui/contributors/ContributorsActivity.java
@@ -13,6 +13,7 @@ import com.T05.krowdtrialz.model.experiment.Experiment;
 import com.T05.krowdtrialz.model.user.User;
 import com.T05.krowdtrialz.ui.subscribed.SubscribedFragment;
 import com.T05.krowdtrialz.util.Database;
+import com.google.firebase.firestore.ListenerRegistration;
 
 import java.util.ArrayList;
 
@@ -24,6 +25,8 @@ public class ContributorsActivity extends AppCompatActivity {
 
     private Experiment currentExperiment;
 
+    private ListenerRegistration expRegistration;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -33,7 +36,7 @@ public class ContributorsActivity extends AppCompatActivity {
 
         Intent intent = getIntent();
         String expID = intent.getStringExtra(MainActivity.EXTRA_EXPERIMENT_ID);
-        Database.getInstance().getExperimentByID(expID, new Database.GetExperimentCallback() {
+        expRegistration = Database.getInstance().getExperimentByID(expID, new Database.GetExperimentCallback() {
             @Override
             public void onSuccess(Experiment experiment) {
                 currentExperiment = experiment;
@@ -51,5 +54,12 @@ public class ContributorsActivity extends AppCompatActivity {
                 currentExperiment = null;
             }
         });
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        // Stop listening to changes in the Database
+        expRegistration.remove();
     }
 }

--- a/app/src/main/java/com/T05/krowdtrialz/ui/search/SearchActivity.java
+++ b/app/src/main/java/com/T05/krowdtrialz/ui/search/SearchActivity.java
@@ -17,14 +17,13 @@ import com.T05.krowdtrialz.model.experiment.Experiment;
 import com.T05.krowdtrialz.ui.experimentDetails.ExperimentDetailsActivity;
 import com.T05.krowdtrialz.util.Database;
 import com.T05.krowdtrialz.util.ExperimentList;
+import com.google.firebase.firestore.ListenerRegistration;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 
 /**
  * Accept user queries and display results.
- *
- * @todo need to update when user re enters the activity, since data may have beed deleted
  */
 public class SearchActivity extends Activity implements SearchView.OnQueryTextListener{
 
@@ -33,6 +32,8 @@ public class SearchActivity extends Activity implements SearchView.OnQueryTextLi
     private final String TAG = "SearchActivity";
     private SearchView searchExperimentsQuery;
     private ListView searchResultsList;
+
+    private ListenerRegistration expRegistration;
 
     public SearchActivity() {
         super();
@@ -86,12 +87,13 @@ public class SearchActivity extends Activity implements SearchView.OnQueryTextLi
         Log.e(TAG, "Query: " + searchString);
         ArrayList<String> tags = new ArrayList<>(Arrays.asList(searchString.split("[^A-Za-z1-9]")));
 
-        db.getExperimentsByTags(tags, new Database.QueryExperimentsCallback() {
+        expRegistration = db.getExperimentsByTags(tags, new Database.QueryExperimentsCallback() {
             @Override
             public void onSuccess(ArrayList<Experiment> experiments) {
                 Log.d(TAG, "Got search results" + experiments.toString());
                 experimentAdapter.clear();
                 experimentAdapter.addAll(experiments);
+                experimentAdapter.notifyDataSetChanged();
 
                 /*
                  * pass the clicked experiment to the Experiment details page
@@ -121,5 +123,12 @@ public class SearchActivity extends Activity implements SearchView.OnQueryTextLi
                 Log.e(TAG, "Error Searching Database");
             }
         });
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        // Stop listening to changes in the Database
+        expRegistration.remove();
     }
 }

--- a/app/src/main/java/com/T05/krowdtrialz/ui/search/SearchActivity.java
+++ b/app/src/main/java/com/T05/krowdtrialz/ui/search/SearchActivity.java
@@ -82,6 +82,11 @@ public class SearchActivity extends Activity implements SearchView.OnQueryTextLi
      *  String with search query
      */
     public void searchExperiments(String searchString) {
+        if (expRegistration != null) {
+            // Remove old ListenerRegistration
+            expRegistration.remove();
+        }
+
         experimentAdapter.clear();
 
         Log.e(TAG, "Query: " + searchString);
@@ -128,7 +133,9 @@ public class SearchActivity extends Activity implements SearchView.OnQueryTextLi
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        // Stop listening to changes in the Database
-        expRegistration.remove();
+        if (expRegistration != null) {
+            // Stop listening to changes in the Database
+            expRegistration.remove();
+        }
     }
 }

--- a/app/src/main/java/com/T05/krowdtrialz/ui/subscribed/SubscribedFragment.java
+++ b/app/src/main/java/com/T05/krowdtrialz/ui/subscribed/SubscribedFragment.java
@@ -1,6 +1,7 @@
 package com.T05.krowdtrialz.ui.subscribed;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -58,6 +59,7 @@ public class SubscribedFragment extends Fragment {
             public void onChanged(ArrayList<Experiment> experiments) {
                 experimentArrayAdapter.clear();
                 experimentArrayAdapter.addAll(experiments);
+                experimentArrayAdapter.notifyDataSetChanged();
             }
         });
 

--- a/app/src/main/java/com/T05/krowdtrialz/ui/subscribed/SubscribedViewModel.java
+++ b/app/src/main/java/com/T05/krowdtrialz/ui/subscribed/SubscribedViewModel.java
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel;
 
 import com.T05.krowdtrialz.model.experiment.Experiment;
 import com.T05.krowdtrialz.util.Database;
+import com.google.firebase.firestore.ListenerRegistration;
 
 import java.util.ArrayList;
 
@@ -17,6 +18,8 @@ public class SubscribedViewModel extends ViewModel {
     private MutableLiveData<ArrayList<Experiment>> experimentsList;
     private static final String TAG = "SubscribedViewModel";
 
+    private ListenerRegistration expRegistration;
+
     public SubscribedViewModel() {
         db = Database.getInstance();
         experimentsList = new MutableLiveData<>();
@@ -24,7 +27,7 @@ public class SubscribedViewModel extends ViewModel {
 
     public LiveData<ArrayList<Experiment>> getExperimentList(){
         db = Database.getInstance();
-        db.getExperimentsBySubscriber(db.getDeviceUser(), new Database.QueryExperimentsCallback() {
+        expRegistration = db.getExperimentsBySubscriber(db.getDeviceUser(), new Database.QueryExperimentsCallback() {
             @Override
             public void onSuccess(ArrayList<Experiment> experiments) {
                 ArrayList<Experiment> newList = new ArrayList<>();
@@ -41,4 +44,10 @@ public class SubscribedViewModel extends ViewModel {
         return experimentsList;
     }
 
+    @Override
+    protected void onCleared() {
+        super.onCleared();
+        // Stop listening to changes in the Database
+        expRegistration.remove();
+    }
 }

--- a/app/src/main/java/com/T05/krowdtrialz/ui/trial/AddBinomialTrialActivity.java
+++ b/app/src/main/java/com/T05/krowdtrialz/ui/trial/AddBinomialTrialActivity.java
@@ -16,6 +16,7 @@ import com.T05.krowdtrialz.model.trial.BinomialTrial;
 import com.T05.krowdtrialz.model.trial.Trial;
 import com.T05.krowdtrialz.model.user.User;
 import com.T05.krowdtrialz.util.Database;
+import com.google.firebase.firestore.ListenerRegistration;
 
 public class AddBinomialTrialActivity extends TrialActivity {
     private Database db;
@@ -27,6 +28,8 @@ public class AddBinomialTrialActivity extends TrialActivity {
     private TextView passTextView;
     private TextView failTextView;
     private BinomialTrial binomialTrial;
+
+    private ListenerRegistration expRegistration;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -42,7 +45,7 @@ public class AddBinomialTrialActivity extends TrialActivity {
         failTextView = findViewById(R.id.binomial2_textView);
 
         Intent intent = getIntent();
-        db.getExperimentByID(intent.getStringExtra(MainActivity.EXTRA_EXPERIMENT_ID), new Database.GetExperimentCallback() {
+        expRegistration = db.getExperimentByID(intent.getStringExtra(MainActivity.EXTRA_EXPERIMENT_ID), new Database.GetExperimentCallback() {
             @Override
             public void onSuccess(Experiment experiment) {
                 BinomialExperiment binomialExperiment = (BinomialExperiment) experiment;
@@ -81,4 +84,11 @@ public class AddBinomialTrialActivity extends TrialActivity {
 
         return binomialTrial;
     } // end createTrial
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        // Stop listening to changes in the Database
+        expRegistration.remove();
+    }
 }// end AddBinomialTrialActivity

--- a/app/src/main/java/com/T05/krowdtrialz/util/Database.java
+++ b/app/src/main/java/com/T05/krowdtrialz/util/Database.java
@@ -465,10 +465,10 @@ public class Database {
         db = FirebaseFirestore.getInstance();
         CollectionReference userCollectionReference = db.collection("Users");
         String ownerID = owner.getId();
-        ArrayList<Experiment> ownedExperiments = new ArrayList<Experiment>();
         ListenerRegistration registration = userCollectionReference.document(ownerID).collection("OwnedExperiments").addSnapshotListener(new EventListener<QuerySnapshot>() {
             @Override
             public void onEvent(@Nullable QuerySnapshot value, @Nullable FirebaseFirestoreException error) {
+                ArrayList<Experiment> ownedExperiments = new ArrayList<Experiment>();
                 for (QueryDocumentSnapshot document : value) {
                     if(document.get("type").toString().equals("Binomial")){
                         BinomialExperiment experiment = document.toObject(BinomialExperiment.class);

--- a/app/src/main/java/com/T05/krowdtrialz/util/MultipleListenerRegistration.java
+++ b/app/src/main/java/com/T05/krowdtrialz/util/MultipleListenerRegistration.java
@@ -1,0 +1,37 @@
+package com.T05.krowdtrialz.util;
+
+import com.google.firebase.firestore.ListenerRegistration;
+
+import java.util.ArrayList;
+
+/**
+ * A ListenerRegistration that holds multiple ListenerRegistration instances.
+ * The remove() method will call remove() on each of the contained instances.
+ * @author Ryan Shukla
+ */
+public class MultipleListenerRegistration implements ListenerRegistration {
+    private ArrayList<ListenerRegistration> registrations;
+
+    public MultipleListenerRegistration() {
+        registrations = new ArrayList<>();
+    }
+
+    /**
+     * Adds a listener registration
+     * @param registration
+     */
+    public void add(ListenerRegistration registration) {
+        registrations.add(registration);
+    }
+
+    /**
+     * Calls remove() on all registrations.
+     */
+    @Override
+    public void remove() {
+        for (ListenerRegistration registration: registrations) {
+            registration.remove();
+        }
+        registrations.clear();
+    }
+}


### PR DESCRIPTION
This modifies the following Database methods to support live updating through the use of firebase snapshot listeners:
- `getUserById`
- `getExperimentsByOwner`
- `getExperimentsBySubscriber`
- `getExperimentsByTags`

It also updates the tests in Database test to pass with the new versions of these methods.

I have added tests called `testLiveUpdateExperiment` and `testSearchThenDelete` to test the live updating functionality.