### PR TITLE
Fix Q&A user info

### DIFF
--- a/app/src/main/java/com/T05/krowdtrialz/model/QnA/Answer.java
+++ b/app/src/main/java/com/T05/krowdtrialz/model/QnA/Answer.java
@@ -2,6 +2,8 @@ package com.T05.krowdtrialz.model.QnA;
 
 import com.T05.krowdtrialz.model.user.User;
 
+import java.util.Objects;
+
 /**
  *  This class represents an answer to a question
  */
@@ -30,5 +32,19 @@ public class Answer {
 
     public void setResponder(User responder) {
         this.responder = responder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Answer answer1 = (Answer) o;
+        return Objects.equals(answer, answer1.answer) &&
+                Objects.equals(responder, answer1.responder);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(answer, responder);
     }
 }

--- a/app/src/main/java/com/T05/krowdtrialz/model/user/User.java
+++ b/app/src/main/java/com/T05/krowdtrialz/model/user/User.java
@@ -69,6 +69,6 @@ public class User {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, userName, email, id);
+        return Objects.hash(id);
     }
 }

--- a/app/src/main/java/com/T05/krowdtrialz/ui/QnA/AnswerViewModel.java
+++ b/app/src/main/java/com/T05/krowdtrialz/ui/QnA/AnswerViewModel.java
@@ -43,6 +43,10 @@ public class AnswerViewModel extends ViewModel {
                         public void onSuccess(User user) {
                             answer.setResponder(user);
                             ArrayList<Answer> tmpList = answerList.getValue();
+                            if (tmpList.contains(answer)) {
+                                // avoid duplicate answers
+                                tmpList.remove(answer);
+                            }
                             tmpList.add(answer);
                             answerList.setValue(tmpList);
                         }

--- a/app/src/main/java/com/T05/krowdtrialz/ui/QnA/QuestionViewModel.java
+++ b/app/src/main/java/com/T05/krowdtrialz/ui/QnA/QuestionViewModel.java
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel;
 
 import com.T05.krowdtrialz.model.QnA.Question;
 import com.T05.krowdtrialz.model.experiment.Experiment;
+import com.T05.krowdtrialz.model.user.User;
 import com.T05.krowdtrialz.util.Database;
 import com.google.firebase.firestore.ListenerRegistration;
 
@@ -31,10 +32,26 @@ public class QuestionViewModel extends ViewModel {
         expRegistration = db.getExperimentByID(expId, new Database.GetExperimentCallback() {
             @Override
             public void onSuccess(Experiment experiment) {
-                ArrayList<Question> newList = new ArrayList<>();
-                newList.addAll(experiment.getQuestions());
-                questionList.setValue(newList);
-                Log.d(TAG, "Got query result: " + experiment.toString());
+                questionList.setValue(new ArrayList<>());
+                Log.d(TAG, "Got experiment query result: " + experiment.toString());
+
+                // Get up to date information about each user
+                for (Question question: experiment.getQuestions()) {
+                    db.getUserByIdNotLive(question.getAskedBy().getId(), new Database.GetUserCallback() {
+                        @Override
+                        public void onSuccess(User user) {
+                            question.setAskedBy(user);
+                            ArrayList<Question> tmpList = questionList.getValue();
+                            tmpList.add(question);
+                            questionList.setValue(tmpList);
+                        }
+
+                        @Override
+                        public void onFailure() {
+                            Log.d(TAG, "Failed to get asked by user with id: " + question.getAskedBy().getId());
+                        }
+                    });
+                }
             }
 
             @Override


### PR DESCRIPTION
This fixes this issue where the User object stored in the database within each Question and Each answer does not have up to date information (e.g. if the username is changed, it is not updated in these places).

This is done by calling `getUserByIdNotLive` for each question/answer.