### PR TITLE
Call ListenerRegistration.remove() in UserActivity.onDestroy()

### DIFF
--- a/app/src/main/java/com/T05/krowdtrialz/ui/owner/UserActivity.java
+++ b/app/src/main/java/com/T05/krowdtrialz/ui/owner/UserActivity.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import com.T05.krowdtrialz.R;
 import com.T05.krowdtrialz.model.user.User;
 import com.T05.krowdtrialz.util.Database;
+import com.google.firebase.firestore.ListenerRegistration;
 
 /**
  * Open the user fragment
@@ -17,6 +18,8 @@ import com.T05.krowdtrialz.util.Database;
 public class UserActivity extends AppCompatActivity {
 
     public static final String USER_ID_EXTRA = "USERID";
+
+    private ListenerRegistration registration;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -26,7 +29,7 @@ public class UserActivity extends AppCompatActivity {
 
         Database db = Database.getInstance();
 
-        db.getUserById(userID, new Database.GetUserCallback() {
+        registration = db.getUserById(userID, new Database.GetUserCallback() {
             @Override
             public void onSuccess(User user) {
                 /**
@@ -45,5 +48,14 @@ public class UserActivity extends AppCompatActivity {
             }
         });
         setContentView(R.layout.activity_user);
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        // Stop listening to changes in the Database
+        if (registration != null) {
+            registration.remove();
+        }
     }
 }


### PR DESCRIPTION
This fixes a crash in `OwnerTests.testEditUserInfo()` where `UserActivity` was trying to create a fragment after the activity had been destroyed. This was happening because the `ListenerRegistration` for `getUserById()` was not removed, allowing the callback could still be called after the activity was destroyed.

![image](https://user-images.githubusercontent.com/4721319/113944220-6d1c8500-97c1-11eb-807e-b816f7a188b4.png)
